### PR TITLE
Replaced Pageobjects with more generalized option -M/--modules

### DIFF
--- a/tests/acceptance/doc/search.robot
+++ b/tests/acceptance/doc/search.robot
@@ -52,7 +52,7 @@
 | | Search for | none shall pass
 | | Page should contain | Searching for 'none shall pass' found 1 keywords
 
-| Search summary, multiple results (searching for X found 6 keywords)
+| Search summary, multiple results (searching for X found 7 keywords)
 | | [Documentation]
 | | ... | Objective: visit a bookmarked search page and verify that
 | | ... | the right number of search terms was found
@@ -60,7 +60,7 @@
 | |
 | | Go to | ${ROOT}/doc
 | | Search for | Fatal
-| | Page should contain | Searching for 'fatal' found 6 keywords
+| | Page should contain | Searching for 'fatal' found 7 keywords
 
 | Correct number of search results - zero results
 | | [Documentation]
@@ -92,7 +92,7 @@
 | | Go to | ${ROOT}/doc
 | | Search for | fatal
 | | ${count}= | Get matching xpath count | xpath=//table[@id='keyword-table']/tbody/tr
-| | Should be equal as integers | ${count} | 6
+| | Should be equal as integers | ${count} | 7
 | | ... | Expected six rows in the table body, got ${count} instead
 
 | Keyword search URL goes to search page
@@ -110,15 +110,15 @@
 | | ... | Objective: verify the name: prefix works
 | | Go to | ${ROOT}/doc
 | | Search for | name:screenshot
-| | Page should contain | Searching for 'screenshot' found 4 keywords
+| | Page should contain | Searching for 'screenshot' found 5 keywords
 
 | Using the in: prefix
 | | [Documentation]
 | | ... | Objective: verify the in: prefix works
 | | Go to | ${ROOT}/doc
 | | Search for | screenshot in:Selenium2Library
-| | Page should contain | Searching for 'screenshot' found 2 keywords
-| | ... | Expected results to include exactly 2 keywords, but it didn't
+| | Page should contain | Searching for 'screenshot' found 3 keywords
+| | ... | Expected results to include exactly 3 keywords, but it didn't
 
 | Clicking search result link shows keyword
 | | [Documentation]
@@ -132,6 +132,7 @@
 | | # N.B. "5" is the expected collection_id of the "Easter" library
 | | # Perhaps that's a bad thing to assume, but since this test suite
 | | # controls which libraries are loaded, it's a reasonably safe bet.
+| | Wait Until Element Is Visible | id=kw-none-shall-pass
 | | Location should be | ${ROOT}/doc/keywords/5/None%20Shall%20Pass/
 
 *** Keywords ***

--- a/tests/acceptance/options.robot
+++ b/tests/acceptance/options.robot
@@ -40,6 +40,15 @@
 | | ... | --no-installed-keywords
 | | ... | do not load some common installed keyword libraries
 
+| Help for option -M/--module
+| | [Documentation]
+| | ... | Verify that the help message includes help for -M/--module
+| | 
+| | Start the hub with options | --help
+| | Output should contain 
+| | ... | -M MODULE, --module MODULE
+| | ... | give the name of a module that exports one or more
+
 
 *** Keywords ***
 | Start the hub with options

--- a/tests/unit/kwdb.robot
+++ b/tests/unit/kwdb.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 | Documentation | Unit tests for the keyword database library 
 | Library       | Collections
+| Library | OperatingSystem
 | Resource      | ${KEYWORD_DIR}/KWDBKeywords.robot
 | Force tags    | kwdb
 | Suite Setup   | Initialize suite variables
@@ -124,7 +125,7 @@
 
 | Initialize suite variables
 | | [Documentation]    | Define some global variables used by the tests in this suite
-| | ${test dir}=       | Evaluate | os.path.dirname("${SUITE SOURCE}") | os
+| | ${test dir}=       | Evaluate | os.path.dirname(r"${SUITE SOURCE}") | os
 | | set suite variable | ${KEYWORD DIR} | ${test dir}/keywords
 | | set suite variable | ${DATA_DIR}    | ${test dir}/data
 


### PR DESCRIPTION
Purpose:
I noticed that when using custom modules structure like pageobjects that the pageobject argument does not work. This change should work to remove the dependency on robotpageobjects while still allowing the ability for mass imports from a module. Also included is one new test for the parameter help menu and updated tests to match new framework changes.

Itemized Changes:
Added Import Error Message to the "unable to load library' message
Switched Parameter -O or --pageobjects With Parameter -M/--module for clarity
Changed Name of PageObjectAction to ModuleAction for Clarity and updated documentation
Removed import from robotpageobjects and check for subclass
Appended error message to "unable to import " message
Added Test for new parameter help menu
Updated old test to match new framework results
Added "r" in SUITE_DIR Evaluate to fix issue with "\" causing bad path