### PR TITLE
change relational imports for Python 3 compatibility

### DIFF
--- a/rfhub/__init__.py
+++ b/rfhub/__init__.py
@@ -1,7 +1,7 @@
 import pkg_resources
 from .version import __version__
 
-import kwdb
+from . import kwdb
 
 # this will be defined once the app starts
 KWDB = None

--- a/rfhub/__main__.py
+++ b/rfhub/__main__.py
@@ -1,4 +1,4 @@
-import app
+from . import app
 
 app.hub = app.RobotHub()
 app.hub.start()

--- a/rfhub/app.py
+++ b/rfhub/app.py
@@ -1,12 +1,12 @@
 from flask import current_app
-from kwdb import KeywordTable
+from .kwdb import KeywordTable
 from rfhub.version import __version__
 from robot.utils.argumentparser import ArgFileParser
 from tornado.httpserver import HTTPServer
 from tornado.wsgi import WSGIContainer
 import tornado.ioloop
 import argparse
-import blueprints
+from . import blueprints
 import flask
 import importlib
 import inspect


### PR DESCRIPTION
I had problems with launching hub with Python 3.5, so I changed imports according to python docs.
https://docs.python.org/3/tutorial/modules.html#intra-package-references