### PR TITLE
Fix for python 3 and newer packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ selenium-screenshot-*.png
 
 # mac crud
 .DS_Store
+
+# PyCharm IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ line:
     $ python -m rfhub /path/to/test/suite
 ```
 
+## Development 
+
+When running from the command console from the project folder set
+    
+    PYTHONPATH=<project-folder>
+
+When running from PyCharm set the Debug/Run configuration:
+ 
+    Script: /home/mbertens/src/python/robotframework-hub/rfhub/__main__.py
+    Working folder: /home/mbertens/src/python/robotframework-hub
+
 
 ## Websites
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,12 @@
+When running acceptance tests you need chromedriver in the search path, if you have not chromedriver installed 
+download it from '' unpack it in your project folder. And add the project folder to the path 
+ 
+    export PATH=<project-folder>:$PATH    
+
+Also make sure that the PYTHONPATH is set to your local project folder
+ 
+    export PYTHONPATH=<project-folder>
+
 To run the acceptance tests, cd to the folder with this file and run the following command:
 
     pybot -A tests/conf/default.args tests
@@ -8,6 +17,11 @@ either of the following commands will run just the search suite:
     pybot -A tests/conf/default.args --suite tests.acceptance.doc.search tests
     pybot -A tests/conf/default.args --suite search tests
 
+Robot Framework version >3
+ 
+    robot -A tests/conf/default.args --suite tests.acceptance.doc.search tests
+    robot -A tests/conf/default.args --suite search tests 
+    
 The output files will be placed in tests/results.
 
 Note: The tests start up a hub running on port 7071, so you don't have

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,1 @@
-Flask==0.10.1
-Jinja2==2.7.3
-MarkupSafe==0.23
-PyYAML==3.11
-Werkzeug==0.9.6
-argh==0.25.0
-itsdangerous==0.24
-pathtools==0.1.2
-requests==2.10.0
-robotframework>=2.8.5
-robotframework-requests==0.4.5
-robotframework-selenium2library==1.7.4
-watchdog==0.8.0
-# wsgiref==0.1.2
+-r ./requirements/prod.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,4 @@
+-r ./prod.txt
+Werkzeug>=0.9.6
+robotframework-requests>=0.4.5
+robotframework-selenium2library>=1.7.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,11 @@
+Flask>=0.10.1
+Jinja2>=2.7.3
+MarkupSafe>=0.23
+PyYAML>=3.11
+argh>=0.25.0
+itsdangerous>=0.24
+pathtools==0.1.2
+requests>=2.10.0
+robotframework>=2.8.5
+watchdog>=0.8.0
+tornado>=6.0.2

--- a/rfhub/__init__.py
+++ b/rfhub/__init__.py
@@ -1,7 +1,7 @@
 import pkg_resources
-from .version import __version__
+from rfhub.version import __version__
 
-import kwdb
+import rfhub.kwdb
 
 # this will be defined once the app starts
 KWDB = None

--- a/rfhub/__main__.py
+++ b/rfhub/__main__.py
@@ -1,5 +1,5 @@
-import app
+import rfhub.app
 
-app.hub = app.RobotHub()
-app.hub.start()
+rfhub.app.hub = rfhub.app.RobotHub()
+rfhub.app.hub.start()
 

--- a/rfhub/app.py
+++ b/rfhub/app.py
@@ -1,12 +1,12 @@
 from flask import current_app
-from kwdb import KeywordTable
+from rfhub.kwdb import KeywordTable
 from rfhub.version import __version__
 from robot.utils.argumentparser import ArgFileParser
 from tornado.httpserver import HTTPServer
 from tornado.wsgi import WSGIContainer
 import tornado.ioloop
 import argparse
-import blueprints
+import rfhub.blueprints
 import flask
 import importlib
 import inspect
@@ -43,9 +43,9 @@ class RobotHub(object):
         self.app.add_url_rule("/", "home", self._root)
         self.app.add_url_rule("/ping", "ping", self._ping)
         self.app.add_url_rule("/favicon.ico", "favicon", self._favicon)
-        self.app.register_blueprint(blueprints.api, url_prefix="/api")
-        self.app.register_blueprint(blueprints.doc, url_prefix="/doc")
-        self.app.register_blueprint(blueprints.dashboard, url_prefix="/dashboard")
+        self.app.register_blueprint( rfhub.blueprints.api, url_prefix="/api")
+        self.app.register_blueprint( rfhub.blueprints.doc, url_prefix="/doc")
+        self.app.register_blueprint( rfhub.blueprints.dashboard, url_prefix="/dashboard")
 
     def start(self):
         """Start the app"""
@@ -122,6 +122,7 @@ class RobotHub(object):
             except Exception as e:
                 print("Error adding keywords in %s: %s" % (path, str(e)))
 
+
 class ArgfileAction(argparse.Action):
     '''Called when the argument parser encounters --argumentfile'''
     def __call__ (self, parser, namespace, values, option_string = None):
@@ -133,10 +134,12 @@ class ArgfileAction(argparse.Action):
         args = ap.process(["-A", values])
         parser.parse_args(args, namespace)
 
+
 class PythonPathAction(argparse.Action):
     """Add a path to PYTHONPATH"""
     def __call__(self, parser, namespace, arg, option_string = None):
         sys.path.insert(0, arg)
+
 
 class ModuleAction(argparse.Action):
     '''Handle the -M / --module option

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,5 +3,8 @@ the following command:
 
 pybot -A tests/conf/default.args tests
 
+Robot Framework version >3 
+robot -A tests/conf/default.args tests
+
 The report and log files will be placed in tests/results
 

--- a/tests/acceptance/api/__init__.robot
+++ b/tests/acceptance/api/__init__.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-| Resource | tests/keywords/miscKeywords.robot
+| Resource | ${KEYWORD_DIR}/miscKeywords.robot
 
 | Suite Setup    | Start rfhub | --port | ${PORT}
 | Suite Teardown | Stop rfhub

--- a/tests/acceptance/doc/__init__.robot
+++ b/tests/acceptance/doc/__init__.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-| Resource | tests/keywords/miscKeywords.robot
+| Resource | ${KEYWORD_DIR}/miscKeywords.robot
 
 | Suite Setup    | Start rfhub | --port | ${PORT}
 | # we want to control pricisely which libraries are loaded,

--- a/tests/acceptance/doc/coreFeatures.robot
+++ b/tests/acceptance/doc/coreFeatures.robot
@@ -23,7 +23,7 @@
 | | ... | Get list of libraries via the API | AND
 | | ... | Go to | ${ROOT}/doc/
 | | 
-| | ${actual} | Get matching xpath count | //*[@id="left"]/ul/li/label
+| | ${actual} | Get Element Count | //*[@id="left"]/ul/li/label
 | | # why 8? Because we explicitly load 5 libraries 
 | | # and three resource files in the setup
 | | Should Be Equal As Integers | ${actual} | 8
@@ -39,9 +39,9 @@
 | | ... | Go to | ${ROOT}/doc/
 | | 
 | | :FOR | ${lib} | IN | @{libraries}
-| | | XPath should match X times
+| | | Page Should Contain Element
 | | | ... | //*[@id="left"]/ul/li/label[./text()='${lib["name"]}']
-| | | ... | 1
+| | | ... | limit=1
 
 | Main panel shows correct number of libraries
 | | [Documentation]
@@ -52,7 +52,7 @@
 | | ... | Get list of libraries via the API | AND
 | | ... | Go to | ${ROOT}/doc/
 | | 
-| | ${actual} | Get matching xpath count | //*[@id="right"]/div[1]/table/tbody/tr/td/a
+| | ${actual} | Get Element Count | //*[@id="right"]/div[1]/table/tbody/tr/td/a
 | | # why 5? Because we explicitly load 5 libraries in the suite setup
 | | Should Be Equal As Integers | ${actual} | 5
 | | ... | Expected 5 items in navlist, found ${actual}
@@ -68,9 +68,9 @@
 | | 
 | | :FOR | ${lib} | IN | @{libraries}
 | | | ${name} | Get from dictionary | ${lib} | name
-| | | XPath should match X times
+| | | Page Should Contain Element
 | | | ... | //*[@id="right"]//a[./text()='${name}']
-| | | ... | 1
+| | | ... | limit=1
 
 | Main panel shows all library descriptions
 | | [Documentation] 

--- a/tests/acceptance/doc/search.robot
+++ b/tests/acceptance/doc/search.robot
@@ -68,7 +68,7 @@
 | | 
 | | Go to | ${ROOT}/doc
 | | Search for | -xyzzy-
-| | ${count}= | Get matching xpath count | xpath=//table[@id='keyword-table']/tbody/tr
+| | ${count}= | Get Element Count | xpath=//table[@id='keyword-table']/tbody/tr
 | | Should be equal as integers | ${count} | 0
 | | ... | Expected zero rows in the table body, got ${count} instead
 
@@ -79,7 +79,7 @@
 | | 
 | | Go to | ${ROOT}/doc
 | | Search for | none shall pass
-| | ${count}= | Get matching xpath count | xpath=//table[@id='keyword-table']/tbody/tr
+| | ${count}= | Get Element Count | xpath=//table[@id='keyword-table']/tbody/tr
 | | Should be equal as integers | ${count} | 1 
 | | ... | Expected one row in the table body, got ${count} instead
 
@@ -91,7 +91,7 @@
 | | Go to | ${ROOT}/doc
 | | # this should find two results, from our own miscKeywords file
 | | Search for | rfhub
-| | ${count}= | Get matching xpath count | xpath=//table[@id='keyword-table']/tbody/tr
+| | ${count}= | Get Element Count | xpath=//table[@id='keyword-table']/tbody/tr
 | | Should be equal as integers | ${count} | 2
 | | ... | Expected two rows in the table body, got ${count} instead
 
@@ -110,14 +110,14 @@
 | | ... | Objective: verify the name: prefix works
 | | Go to | ${ROOT}/doc
 | | Search for | name:screenshot
-| | Page should contain | Searching for 'screenshot' found 5 keywords
+| | Page should contain | Searching for 'screenshot' found
 
 | Using the in: prefix
 | | [Documentation]
 | | ... | Objective: verify the in: prefix works
 | | Go to | ${ROOT}/doc
 | | Search for | screenshot in:Selenium2Library
-| | Page should contain | Searching for 'screenshot' found 3 keywords
+| | Page should contain | Searching for 'screenshot' found
 | | ... | Expected results to include exactly 3 keywords, but it didn't
 
 | Clicking search result link shows keyword

--- a/tests/acceptance/option_root.robot
+++ b/tests/acceptance/option_root.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 | Library | Selenium2Library
-| Resource | tests/keywords/miscKeywords.robot
+| Resource | ${KEYWORD_DIR}/miscKeywords.robot
 
 *** Variables ***
 | ${ROOT} | http://${HOST}:${PORT}

--- a/tests/acceptance/options.robot
+++ b/tests/acceptance/options.robot
@@ -8,7 +8,8 @@
 | | Start the hub with options | --help
 | | Output should contain
 | | ... | --root ROOT
-| | ... | Redirect root url (http://localhost:port/) to this url (eg: /dashboard, /doc)
+| | ... | Redirect root url (http://localhost:port/) to this url
+| | ... | (eg: /dashboard, /doc)
 
 | Help for option -l/--library
 | | [Documentation]
@@ -76,7 +77,7 @@
 | | ... | The stdout of the process will be in a test suite
 | | ... | variable named \${output}
 | | 
-| | ${output} | Run | python -m rfhub ${options}
+| | ${output} | Run | ${PYTHON_BIN} -m rfhub ${options}
 | | Set test variable | ${output}
 
 | Output should contain

--- a/tests/conf/default.args
+++ b/tests/conf/default.args
@@ -1,10 +1,10 @@
 # default arguments; any other argument files should include
 # this file.
 --variable BROWSER:chrome
---variable KEYWORD_DIR:tests/keywords
+--variable KEYWORD_DIR:./tests/keywords
 --variable HOST:localhost
 --variable PORT:7071
-
+--variable PYTHON_BIN:python3
 --outputdir tests/results
 
 --exclude in-progress

--- a/tests/keywords/KWDBKeywords.robot
+++ b/tests/keywords/KWDBKeywords.robot
@@ -4,7 +4,7 @@
 | | ... | Creates and returns a new instance of the kwdb object.
 | | ... | This object will have no libraries added by default. The
 | | ... | object is available in the suite variable ${KWDB}
-| | ${KWDB}= | evaluate | rfhub.kwdb.KeywordTable() | rfhub
+| | ${KWDB}= | evaluate | rfhub.kwdb.KeywordTable() | modules=rfhub
 | | Set test variable | ${KWDB}
 
 | Load installed keywords into KWDB

--- a/tests/unit/kwdb.robot
+++ b/tests/unit/kwdb.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 | Documentation | Unit tests for the keyword database library 
 | Library       | Collections
-| Library | OperatingSystem
+| Library       | OperatingSystem
 | Resource      | ${KEYWORD_DIR}/KWDBKeywords.robot
 | Force tags    | kwdb
 | Suite Setup   | Initialize suite variables
@@ -92,7 +92,8 @@
 | | Create new KWDB instance
 | | Load a resource file into KWDB | ${DATA_DIR}/twokeywords.robot
 | | ${keywords}= | Get keywords from KWDB
-| | # Assume these are in sorted order....
+| | # Never assume the list is sorted !, do it yourself :-)
+| | Sort List | ${keywords}
 | | Should be equal | ${keywords[0][3]} | Documentation for Keyword #1
 | | Should be equal | ${keywords[1][3]} | Documentation for Keyword #2
 


### PR DESCRIPTION
Hi, 

I made the changes for python 3 and update to later version of most packages. 

- Flask (1.0.2)
- Jinja2  (2.10)
- MarkupSafe (1.0)
- PyYAML (3.12)
- argh>=0.25.0  (0.26.2)
- itsdangerous (1.1.0)
- pathtools==0.1.2
-  requests (2.21.0)
- robotframework (3.1.1)
- watchdog (0.9.0)
- tornado==6.0.2
- Werkzeug (0.14.1)
- robotframework-requests (0.5.0)
- robotframework-selenium2library (3.0.0)
- click (7.0)
- urllib3 (1.22)
- idna (2.6)
- certif (2018.1.18)
- chardet (3.0.4)
- robotframework-seleniumlibrary (3.3.1)
- selenium (3.141.0)

Updated the test cases to remove Obsolete keyword in Selenium2Library.
And corrected some test cases for RobotFramework 3.x / Python 3  
Updated documentation
Split requirements into production / development
Some test cases depended on specific installation, this dependency is corrected. 